### PR TITLE
Handle Resend failures gracefully in contact API

### DIFF
--- a/api/contact.ts
+++ b/api/contact.ts
@@ -94,22 +94,27 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const empresaLine = empresa ? `\nEmpresa: ${empresa}` : "";
   const bodyText = `Nueva solicitud de presupuesto:\n\nNombre: ${nombre}\nEmail: ${email}${empresaLine}\n\nMensaje:\n${mensaje}\n\n—\nEste correo fue enviado automáticamente por la web.`;
 
-  // Use Reply-To so replying goes to the client
-  await resend.emails.send({
-    from: fromEmail,
-    to: toEmail,
-    subject,
-    text: bodyText,
-    headers: { "Reply-To": email },
-  });
+  try {
+    // Use Reply-To so replying goes to the client
+    await resend.emails.send({
+      from: fromEmail,
+      to: toEmail,
+      subject,
+      text: bodyText,
+      headers: { "Reply-To": email },
+    });
 
-  // Auto-response to client
-  await resend.emails.send({
-    from: fromEmail,
-    to: email,
-    subject: "Hemos recibido tu solicitud",
-    text: `Hola ${nombre},\n\nGracias por contactarnos. Hemos recibido tu solicitud y te responderemos en menos de 24h.\n\nUn saludo,\nGeotecnia y Servicios`,
-  });
+    // Auto-response to client
+    await resend.emails.send({
+      from: fromEmail,
+      to: email,
+      subject: "Hemos recibido tu solicitud",
+      text: `Hola ${nombre},\n\nGracias por contactarnos. Hemos recibido tu solicitud y te responderemos en menos de 24h.\n\nUn saludo,\nGeotecnia y Servicios`,
+    });
+  } catch (err) {
+    console.error("Error enviando correos de contacto", err);
+    return res.status(200).json({ ok: true, warning: "No se pudieron enviar los correos" });
+  }
 
   return res.status(200).json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- wrap Resend email sends in try/catch
- return warning response instead of crashing when email sending fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 17 problems, 9 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68b3149d5310832e91b165ab8c41b4d4