### PR TITLE
Render reCAPTCHA widget and submit token

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -12,6 +12,11 @@ interface ImportMeta {
 interface Window {
   grecaptcha?: {
     ready(cb: () => void): void
-    execute(siteKey: string, opts: { action: string }): Promise<string>
+    render(
+      container: string | HTMLElement,
+      opts: { sitekey: string; callback: (token: string) => void }
+    ): number
+    reset(id?: number): void
+    execute?(siteKey: string, opts: { action: string }): Promise<string>
   }
 }


### PR DESCRIPTION
## Summary
- load reCAPTCHA v2 script and render a visible widget
- collect widget token and send with contact form
- type grecaptcha render/reset helpers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b322e5afcc832e9589ca159036dfae