### PR TITLE
Handle contact form without reCAPTCHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Environment Variables
+
+The contact form can optionally use [Google reCAPTCHA](https://www.google.com/recaptcha/about/). To enable it, define the following variables:
+
+- `RECAPTCHA_SECRET` – server-side secret used to verify tokens.
+- `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` – site key exposed to the client.
+
+If these variables are not set, the form will still submit but reCAPTCHA will be skipped.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/d0de79a3-a689-4052-9509-e47cea7a97e5) and click on Share -> Publish.

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -22,9 +22,7 @@ const scrollTo = (id: string) => {
 
 const Index = () => {
   const heroRef = useRef<HTMLDivElement | null>(null);
-  const siteKey =
-    import.meta.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY ??
-    import.meta.env.VITE_RECAPTCHA_SITE_KEY;
+  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
 
   useEffect(() => {
     // Load reCAPTCHA v3 script dynamically if site key is configured
@@ -122,13 +120,11 @@ const Index = () => {
     }
 
     try {
-      if (!siteKey || !window.grecaptcha) {
-        toast({ title: "Verificación requerida", description: "reCAPTCHA no disponible." });
-        return;
+      let recaptchaToken: string | undefined;
+      if (siteKey && window.grecaptcha) {
+        await new Promise<void>((resolve) => window.grecaptcha!.ready(resolve));
+        recaptchaToken = await window.grecaptcha!.execute(siteKey, { action: "submit" });
       }
-
-      await new Promise<void>((resolve) => window.grecaptcha!.ready(resolve));
-      const recaptchaToken = await window.grecaptcha!.execute(siteKey, { action: "submit" });
 
       const res = await fetch("/api/contact", {
         method: "POST",

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,17 +1,9 @@
 /// <reference types="vite/client" />
-
-interface ImportMetaEnv {
-  readonly VITE_RECAPTCHA_SITE_KEY?: string
-  readonly NEXT_PUBLIC_RECAPTCHA_SITE_KEY?: string
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv
-}
+/// <reference types="node" />
 
 interface Window {
   grecaptcha?: {
-    ready(cb: () => void): void
-    execute(siteKey: string, opts: { action: string }): Promise<string>
-  }
+    ready(cb: () => void): void;
+    execute(siteKey: string, opts: { action: string }): Promise<string>;
+  };
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,22 +1,34 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [
-    react(),
-    mode === 'development' &&
-    componentTagger(),
-  ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const publicEnv = Object.fromEntries(
+    Object.entries(env).filter(([key]) =>
+      key.startsWith("VITE_") || key.startsWith("NEXT_PUBLIC_")
+    )
+  );
+
+  return {
+    server: {
+      host: "::",
+      port: 8080,
     },
-  },
-}));
+    envPrefix: ["VITE_", "NEXT_PUBLIC_"],
+    define: {
+      "process.env": JSON.stringify(publicEnv),
+    },
+    plugins: [
+      react(),
+      mode === 'development' && componentTagger(),
+    ].filter(Boolean),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- allow contact form to submit even if reCAPTCHA is not configured
- expose public env vars through `process.env` for Vite builds
- document optional reCAPTCHA environment variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b33a95c9e4832ebcd44e212bcf8bac